### PR TITLE
Catch ValidationError to fix invalid groups test

### DIFF
--- a/test/mocha/GroupsTest.js
+++ b/test/mocha/GroupsTest.js
@@ -35,8 +35,8 @@ async.series([
             it("Should not add a new group", function (done) {
                 group.title = undefined;
                 Group.create(group, function (err, g) {
-                    if (err) throw err;
-                    expect(g).to.be(undefined);
+                    expect(err.name).to.be("ValidationError");
+                    expect(g).to.be(undefined)
                     done();
                 });
             });


### PR DESCRIPTION
Addresses failing group unit tests #46 