### PR TITLE
Non-admin adding group & some additional bug fixes

### DIFF
--- a/client/src/App/actions/groups.js
+++ b/client/src/App/actions/groups.js
@@ -44,7 +44,7 @@ export const startNewSemester = (name) => (dispatch, getState) => {
         .send({ 'semesterName': name })
         .then(response => {
             toastr.success('Success', `Started New Semester: "${name}"`);
-            
+
         })
         .catch(err => {
             toastr.error('Error', `Could Not Start Semester "${name}"`);
@@ -63,6 +63,10 @@ export const fetchGroupsIfNeeded = () => (dispatch, getState) => {
 
 export const addGroup = (group) => (dispatch, getState) => {
     group.members = [];
+    if (!group.leaders || group.leaders.length <= 0 || !getState().identity.roles.includes('admin')) {
+        group.leaders = [getState().identity._id];
+    }
+
     dispatch({
         type: ADD_GROUP,
         group

--- a/client/src/App/components/groups/createEdit/GroupCreateEditSurface.jsx
+++ b/client/src/App/components/groups/createEdit/GroupCreateEditSurface.jsx
@@ -21,21 +21,25 @@ class GroupCreateEditSurface extends React.Component {
     }
     submit(group) {
         const { dispatch, initialValues } = this.props;
-       /* if (group.members) {
-            group.members = group.members.map(m => {
-                if (!m.status) {
-                    m.status = 'PENDING';
-                }
-                if (!m.preferContactVia)
-                {
-                    m.preferContactVia = 'email';
-                }   
-                return member
-            });
-        }*/
+        /* if (group.members) {
+             group.members = group.members.map(m => {
+                 if (!m.status) {
+                     m.status = 'PENDING';
+                 }
+                 if (!m.preferContactVia)
+                 {
+                     m.preferContactVia = 'email';
+                 }   
+                 return member
+             });
+         }*/
         // topics get passed from the form as a single string value, 
         // but must be passed to the server as an array
         group.topics = [group.topics];
+        if (!group.leaders) {
+            group.leaders = [];
+        }
+
         this.refs.confirm.show()
             .then(() => {
                 if (initialValues) {
@@ -110,9 +114,9 @@ class GroupCreateEditSurface extends React.Component {
                                                 <td >
                                                     {m.emergency_contact ? m.emergency_contact.firstName + ' ' + m.emergency_contact.lastName : 'No contact info. May have been added by group leader.'}</td>
                                                 <td >
-                                                    {m.emergency_contact ? m.emergency_contact.email: null}</td>
+                                                    {m.emergency_contact ? m.emergency_contact.email : null}</td>
                                                 <td >
-                                                    {m.emergency_contact ? m.emergency_contact.phone: null}
+                                                    {m.emergency_contact ? m.emergency_contact.phone : null}
                                                 </td>
                                             </tr>
                                         ))}

--- a/client/src/App/components/groups/createEdit/LeaderCheckboxGroup.jsx
+++ b/client/src/App/components/groups/createEdit/LeaderCheckboxGroup.jsx
@@ -21,7 +21,7 @@ const LeaderCheckboxGroup = (props) => {
                         <input
                             type="checkbox"
                             name={`${name}[${index}]`}
-                            disabled={option._id === identity._id && !identity.roles.includes('admin')}
+                            disabled={!identity.roles.includes('admin')}
                             value={option._id}
                             checked={isChecked(option)}
                             onChange={event => {

--- a/client/src/App/components/groups/list/ListSurface.jsx
+++ b/client/src/App/components/groups/list/ListSurface.jsx
@@ -61,7 +61,7 @@ class ListSurface extends React.Component {
                             <InfoWell />
                         </Col>
                         <Col md={9} >
-                            {hasGroups && (!settings.showNextSemesterMsg || identity.roles.includes('admin')) ? <ListTable groups={groups} /> : null}
+                            {hasGroups && (!settings.showNextSemesterMsg || (identity._id)) ? <ListTable groups={groups} /> : null}
                         </Col>
                     </Row>
                 </div>

--- a/server/controllers/groupsController.js
+++ b/server/controllers/groupsController.js
@@ -112,7 +112,13 @@ exports.updateGroup = function (req, res) {
     delete groupUpdates['_id'];
 
     // if this is not an admin then the group must contain the current user as one of its leaders
-    if (!req.user.hasRole('admin') && groupUpdates.leaders.indexOf(req.user.id) < 0) {
+    if (!req.user.hasRole('admin') &&
+        groupUpdates.leaders.indexOf(req.user.id) < 0 && groupUpdates.leaders.map(l => l._id).indexOf(req.user.id) < 0) {
+        console.log(`Group was attempted to be updated by a non-admin, non-leader
+        User: ${req.user.id}
+        Leaders: ${groupUpdates.leaders.map(l => l._id)}
+        `);
+
         res.status(403);
         return res.end();
     }


### PR DESCRIPTION
Addresses issue #214 by auto adding the logged in user as the leader when no leader is added as this is the desired functionality when the website was originally created.

Also correctly disables/enables leader checkboxes for non-admin users.

Fixes other UI bugs.